### PR TITLE
Parse Keepass History entries and attach to PasswordEntry.history when parsing XML

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -336,10 +336,7 @@ const Index = () => {
       return { value: encrypted, readonly: true };
     };
 
-    const entries: PasswordEntry[] = [];
-
-    const entryEls = Array.from(doc.getElementsByTagName('Entry'));
-    for (const entryEl of entryEls) {
+    const parseEntryData = async (entryEl: Element, entryId: string) => {
       const stringEls = Array.from(entryEl.getElementsByTagName('String'));
 
       const kv = new Map<string, { value: string; protectInMemory: boolean }>();
@@ -386,8 +383,8 @@ const Index = () => {
           })
       );
 
-      entries.push({
-        id: crypto.randomUUID(),
+      return {
+        id: entryId,
         title: title.trim() || 'Untitled',
         username,
         password: passwordRes.value,
@@ -398,7 +395,38 @@ const Index = () => {
         customFields,
         createdAt,
         updatedAt,
-        history: [],
+      };
+    };
+
+    const entries: PasswordEntry[] = [];
+
+    // Important: <History> itself contains <Entry> tags. We only want "real" entries here,
+    // and map the historical <Entry> versions into `history`.
+    const entryEls = Array.from(doc.getElementsByTagName('Entry')).filter(el => !el.closest('History'));
+
+    for (const entryEl of entryEls) {
+      const id = crypto.randomUUID();
+
+      const data = await parseEntryData(entryEl, id);
+
+      const historyEl = entryEl.getElementsByTagName('History')[0];
+      const historyEntryEls = historyEl ? Array.from(historyEl.getElementsByTagName('Entry')) : [];
+
+      const history = (await Promise.all(
+        historyEntryEls.map(async (historyEntryEl) => {
+          const historyData = await parseEntryData(historyEntryEl, id);
+          return {
+            timestamp: historyData.updatedAt,
+            data: historyData,
+          };
+        })
+      ))
+        .filter(h => !Number.isNaN(h.timestamp.getTime()))
+        .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+
+      entries.push({
+        ...data,
+        history,
       });
     }
 


### PR DESCRIPTION
Adds processing of <History> sections in Keepass XML during parsing, so historical versions of entries are captured in the PasswordEntry.history array.

What changed:
- Introduced parseEntryData helper to parse individual Entry-like elements consistently.
- Iterate over top-level <Entry> elements (excluding those nested under <History>) to build current entries, assigning a unique id per entry.
- For each entry, read its <History> child and map each historical <Entry> into a history item with a timestamp (derived from updatedAt) and the historical data payload.
- History is sorted by timestamp in descending order and exposed as the history property on the PasswordEntry, enabling UI to show change history.
- History entries share the same parent entry id, ensuring linkage between current and historical versions.

Result:
- The parser now produces PasswordEntry objects that include a populated history array sourced from the Keepass <History> contents instead of an empty history. This enables history-driven features in the UI and aligns with the Keepass data model.

https://cosine.sh/stud0709/oms4web/task/uzbkp5t8mvd0
https://cosine.sh/gh/stud0709/oms4web/pull/8
Author: Yuriy Dzhenyeyev