### PR TITLE
docs: add user guide for Merge feature (merge.md)

### DIFF
--- a/merge.md
+++ b/merge.md
@@ -1,0 +1,48 @@
+# Merge
+
+The **Merge** action lets you **add entries from another file into your currently opened vault** without replacing what you already have.
+
+## Where to find it
+
+On the main vault screen, click the **Merge** button (the *Git merge* icon) in the top toolbar.
+
+## What you can merge
+
+Merge accepts these file types:
+
+- **oms4web export JSON**: `.json`
+- **Encrypted oms4web export**: `.oms00`
+  - You’ll be prompted to decrypt it before merging.
+- **KeePass XML export**: `.xml`
+
+## How merging works (what you will see)
+
+1. Click **Merge** and choose a file.
+2. If the file is encrypted (`.oms00`), a decrypt dialog opens. After a successful decrypt, merging continues.
+3. A confirmation dialog opens:
+   - It shows how many entries will be added.
+   - You can choose a **tag for merged entries**.
+     - A default tag is suggested in the form `merged_YYYY_MM_DD`.
+4. Click **Merge** to finish.
+
+After merging:
+
+- The imported entries are added to your vault (your existing entries remain unchanged).
+- All merged entries receive the tag you chose (in addition to any tags they already had).
+
+## KeePass XML notes
+
+- KeePass entries are imported as new vault entries.
+- KeePass group names are converted into tags (walking up parent groups).
+- KeePass entry history is imported when present.
+- If a KeePass field is marked as **protected** (e.g. password/custom fields with `ProtectInMemory="True"`), oms4web needs its **"password generator & encryption"** setting enabled to import it as a protected value. Otherwise, merge is blocked and you’ll be prompted to enable that setting.
+
+## Duplicate/Collision behavior
+
+- If a merged entry’s internal ID conflicts with an existing entry, oms4web automatically assigns a new ID to the merged entry.
+- Merge does **not** try to detect “same login/site” duplicates. If the other file contains entries that look similar to yours, they will still be added as separate entries.
+
+## Troubleshooting
+
+- **“Unknown file format, cannot merge”**: the selected file is not a supported JSON export, `.oms00` file, or KeePass XML export.
+- **“Cannot merge KeePass XML”**: enable **"password generator & encryption"** in Settings if the KeePass file contains protected fields.


### PR DESCRIPTION
Adds merge.md alongside README.md to document the Merge feature from a user perspective. The document explains how to use Merge, what file types are supported, how the merging flow works, and what to expect after merging, plus KeePass-specific notes, duplicate handling, and troubleshooting.

What’s inside:
- Where to find it: On the main vault screen, click the Merge button (Git merge icon) in the top toolbar.
- What you can merge: oms4web export JSON (.json), encrypted oms4web export (.oms00) with decrypt, KeePass XML export (.xml).
- How merging works: select a file, decrypt if needed, confirm details, choose/accept a default tag merged_YYYY_MM_DD, then merge.
- Post-merge behavior: imported entries are added without changing existing ones; merged entries receive the chosen tag in addition to existing tags.
- KeePass notes: KeePass entries become new vault entries; group names are converted to tags; history is imported; protected fields require enabling the password generator & encryption setting to import as protected values.
- Duplicate/Collision behavior: if IDs collide, a new ID is assigned; no automatic deduplication for similar login/site entries.
- Troubleshooting: common errors such as unknown file format or inability to merge KeePass XML due to missing settings.

https://cosine.sh/stud0709/oms4web/task/lutrjbdiep3f
https://cosine.sh/gh/stud0709/oms4web/pull/12
Author: Yuriy Dzhenyeyev