### PR TITLE
Truncate long URLs in PasswordCard to prevent card width expansion

### DIFF
--- a/src/components/PasswordCard.tsx
+++ b/src/components/PasswordCard.tsx
@@ -197,9 +197,10 @@ export function PasswordCard({
                   href={entryToDisplay.url.startsWith('http') ? entryToDisplay.url : `https://${entryToDisplay.url}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground hover:text-primary flex items-center gap-1 transition-colors min-w-0"
+                  title={entryToDisplay.url}
+                  className="text-sm text-muted-foreground hover:text-primary flex flex-1 items-center gap-1 transition-colors min-w-0 overflow-hidden"
                 >
-                  <span className="truncate">{entryToDisplay.url}</span>
+                  <span className="truncate block">{entryToDisplay.url}</span>
                   <ExternalLink className="h-3 w-3 flex-shrink-0" />
                 </a>
                 {!referenceMode && (


### PR DESCRIPTION
- Truncate the displayed URL by applying overflow-hidden and making the URL span a block element, so it doesn't cause the card to grow horizontally.
- Add a title attribute on the link to show the full URL on hover while keeping the truncated display.
- Preserve the existing link behavior and ExternalLink icon; ensure layout uses flex-1 so truncation takes effect within available space.

https://cosine.sh/stud0709/oms4web/task/q5uq3d26ta5t
https://cosine.sh/gh/stud0709/oms4web/pull/17
Author: Yuriy Dzhenyeyev