### PR TITLE
Enable multi-tag hashtag filtering with chainable filters and clear controls

### DIFF
--- a/src/components/HashtagFilter.tsx
+++ b/src/components/HashtagFilter.tsx
@@ -1,26 +1,27 @@
 import { Hash, X } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
-import { 
-  ScrollArea, 
+import {
+  ScrollArea,
   ScrollBar } from '@/components/ui/scroll-area';
 
 interface HashtagFilterProps {
   tags: string[];
-  selectedTag: string | null;
-  onSelectTag: (tag: string | null) => void;
+  selectedTags: Set<string>;
+  onToggleTag: (tag: string) => void;
+  onClear: () => void;
 }
 
-export function HashtagFilter({ tags, selectedTag, onSelectTag }: HashtagFilterProps) {
+export function HashtagFilter({ tags, selectedTags, onToggleTag, onClear }: HashtagFilterProps) {
   if (tags.length === 0) return null;
 
   return (
     <ScrollArea className="w-full whitespace-nowrap">
       <div className="flex gap-2 pb-2">
-        {selectedTag && (
+        {selectedTags.size > 0 && (
           <Badge
             variant="outline"
             className="cursor-pointer hover:bg-destructive/10 border-destructive/50 text-destructive"
-            onClick={() => onSelectTag(null)}
+            onClick={onClear}
           >
             <X className="h-3 w-3 mr-1" />
             Clear filter
@@ -28,8 +29,8 @@ export function HashtagFilter({ tags, selectedTag, onSelectTag }: HashtagFilterP
         )}
         {tags.map(tag => {
           const isDeletedTag = tag === 'deleted';
-          const isSelected = selectedTag === tag;
-          
+          const isSelected = selectedTags.has(tag);
+
           return (
             <Badge
               key={tag}
@@ -37,7 +38,7 @@ export function HashtagFilter({ tags, selectedTag, onSelectTag }: HashtagFilterP
               className={`cursor-pointer transition-all hover:scale-105 ${
                 isDeletedTag && !isSelected ? 'opacity-70' : ''
               }`}
-              onClick={() => onSelectTag(isSelected ? null : tag)}
+              onClick={() => onToggleTag(tag)}
             >
               <Hash className="h-3 w-3 mr-0.5" />
               {tag}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -8,9 +8,13 @@ import { Button } from '@/components/ui/button';
 interface SearchBarProps {
   value: string;
   onChange: (value: string) => void;
+  showClear?: boolean;
+  onClear?: () => void;
 }
 
-export function SearchBar({ value, onChange }: SearchBarProps) {
+export function SearchBar({ value, onChange, showClear, onClear }: SearchBarProps) {
+  const shouldShowClear = Boolean(value) || Boolean(showClear);
+
   return (
     <div className="relative">
       <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
@@ -20,12 +24,18 @@ export function SearchBar({ value, onChange }: SearchBarProps) {
         placeholder="Search entries..."
         className="pl-10 pr-10 h-12 text-base bg-card border-border/50 focus:border-primary/50"
       />
-      {value && (
+      {shouldShowClear && (
         <Button
           variant="ghost"
           size="icon"
           className="absolute right-1 top-1/2 -translate-y-1/2 h-8 w-8"
-          onClick={() => onChange('')}
+          onClick={() => {
+            if (onClear) {
+              onClear();
+              return;
+            }
+            onChange('');
+          }}
         >
           <X className="h-4 w-4" />
         </Button>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -76,7 +76,7 @@ const Index = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const mergeFileInputRef = useRef<HTMLInputElement>(null);
   const [search, setSearch] = useState('');
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
   const [formOpen, setFormOpen] = useState(false);
   const [editingEntry, setEditingEntry] = useState<PasswordEntry | null>(null);
   const [importDecryptData, setImportDecryptData] = useState<Uint8Array | null>(null);
@@ -122,13 +122,16 @@ const Index = () => {
         if (result.length && PASSWORD_READONLY_PROPERTY_NAME in result[0]) {
           return result;
         }
-        throw "Result is not PasswordEntry[]"
+        throw "Result is not PasswordEntry[]";
       } catch (err) {
         console.log(err);
         toast({ title: 'Invalid JSONPath query', description: `${err}` });
 
       }
     }
+
+    const selectedTagsArr = Array.from(selectedTags);
+
     return vaultData.entries.filter(entry => {
       const matchesSearch = !search ||
         entry.title.toLowerCase().includes(search.toLowerCase()) ||
@@ -136,15 +139,37 @@ const Index = () => {
         entry.url.toLowerCase().includes(search.toLowerCase()) ||
         entry.hashtags.some(tag => tag.includes(search.toLowerCase()));
 
-      const matchesTag = !selectedTag || entry.hashtags.includes(selectedTag);
+      const matchesTags = selectedTagsArr.length === 0 || selectedTagsArr.every(tag => entry.hashtags.includes(tag));
 
       // Hide deleted entries unless #deleted tag is explicitly selected
       const isDeleted = entry.hashtags.includes(DELETED_TAG);
-      const showDeleted = selectedTag === DELETED_TAG;
+      const showDeleted = selectedTags.has(DELETED_TAG);
 
-      return matchesSearch && matchesTag && (!isDeleted || showDeleted);
+      return matchesSearch && matchesTags && (!isDeleted || showDeleted);
     });
-  }, [vaultData, search, selectedTag, toast]);
+  }, [vaultData, search, selectedTags, toast]);
+
+  const visibleTags = useMemo(() => {
+    if (selectedTags.size === 0) return allTags;
+
+    const tagsInResults = new Set<string>();
+    for (const entry of filteredEntries) {
+      for (const tag of entry.hashtags) {
+        tagsInResults.add(tag);
+      }
+    }
+
+    for (const tag of selectedTags) {
+      tagsInResults.add(tag);
+    }
+
+    const ordered = allTags.filter(t => tagsInResults.has(t));
+    for (const tag of selectedTags) {
+      if (!ordered.includes(tag)) ordered.unshift(tag);
+    }
+
+    return ordered;
+  }, [allTags, filteredEntries, selectedTags]);
 
   const handleSave = (data: Omit<PasswordEntry, 'id' | 'createdAt' | 'updatedAt' | 'history'>) => {
     if (editingEntry) {
@@ -153,7 +178,7 @@ const Index = () => {
       addEntry(data);
       // Ensure the newly created entry is visible immediately
       setSearch('');
-      setSelectedTag(null);
+      setSelectedTags(new Set());
     }
     setEditingEntry(null);
   };
@@ -180,11 +205,11 @@ const Index = () => {
   const handleSearchChange = (value: string) => {
     if (value.startsWith(OMS4WEB_REF)) {
       //clear tag selection
-      setSelectedTag(null)
+      setSelectedTags(new Set());
     }
 
-    setSearch(value)
-  }
+    setSearch(value);
+  };
 
   const downloadVaultSnapshot = async ({
     suffix,
@@ -570,12 +595,26 @@ const Index = () => {
     );
   }
 
-  const handleSelectedTag = (tag: string) => {
+  const clearAllFilters = () => {
+    setSearch('');
+    setSelectedTags(new Set());
+  };
+
+  const handleToggleTag = (tag: string) => {
     if (search?.startsWith(OMS4WEB_REF)) {
       setSearch('');
     }
-    setSelectedTag(tag);
-  }
+
+    setSelectedTags(prev => {
+      const next = new Set(prev);
+      if (next.has(tag)) {
+        next.delete(tag);
+      } else {
+        next.add(tag);
+      }
+      return next;
+    });
+  };
 
   return (
     <div className="h-dvh flex flex-col overflow-hidden">
@@ -633,13 +672,19 @@ const Index = () => {
               <ScrollBar orientation="horizontal" />
             </ScrollArea>
           </div>
-          <SearchBar value={search} onChange={handleSearchChange} />
-          {allTags.length > 0 && (
+          <SearchBar
+            value={search}
+            onChange={handleSearchChange}
+            showClear={selectedTags.size > 0}
+            onClear={clearAllFilters}
+          />
+          {visibleTags.length > 0 && (
             <div className="mt-6">
               <HashtagFilter
-                tags={allTags}
-                selectedTag={selectedTag}
-                onSelectTag={handleSelectedTag}
+                tags={visibleTags}
+                selectedTags={selectedTags}
+                onToggleTag={handleToggleTag}
+                onClear={clearAllFilters}
               />
             </div>
           )}
@@ -662,7 +707,7 @@ const Index = () => {
                   onEdit={handleEdit}
                   onDelete={deleteEntry}
                   onSoftDelete={handleSoftDelete}
-                  onTagClick={setSelectedTag}
+                  onTagClick={handleToggleTag}
                   applyRef={applyRef}
                   setSearch={setSearch}
                 />
@@ -707,7 +752,7 @@ const Index = () => {
         {filteredEntries.length > 0 && (
           <p className="text-center text-sm text-muted-foreground mt-8">
             {filteredEntries.length} {filteredEntries.length === 1 ? 'entry' : 'entries'}
-            {selectedTag && ` tagged #${selectedTag}`}
+            {selectedTags.size > 0 && ` tagged ${Array.from(selectedTags).map(t => `#${t}`).join(' ')}`}
           </p>
         )}
       </div>


### PR DESCRIPTION
This PR updates the hashtag filtering to support multiple selected tags and makes the filter chainable with a clear all option.

What changed:
- HashtagFilter.tsx
  - Reworked to accept a Set<string> of selectedTags, plus onToggleTag and onClear callbacks.
  - Shows a Clear filter badge (X) when any tag is selected; clicking it clears all filters.
  - Tag items now toggle their presence in selectedTags via onToggleTag.

- SearchBar.tsx
  - Added showClear and onClear props. The clear button is shown when there is input or when showClear is true.
  - Clear behavior now calls onClear if provided, otherwise clears the input value.

- Index.tsx (page state & logic)
  - Replaced single selectedTag with a Set<string> selectedTags to support multiple selections.
  - Filtering logic now requires all selected tags to be present in an entry (AND across tags).
  - Added visibleTags: a memoized list of tags that exist in the currently visible entries. This makes the tag list itself filter to tags present in the results, enabling further narrowing by clicking additional tags.
  - clearAllFilters resets search and selectedTags.
  - handleToggleTag toggles a tag’s presence in selectedTags.
  - SearchBar now shows a clear button when any tag is selected and when the search input is present.
  - UI text reflects multiple selected tags (e.g., tagged #tag1 #tag2).

Rationale:
- This allows users to chain multiple tag filters by clicking several tags. The tag list updates to only include tags that appear in the currently filtered results, making the UI more intuitive for narrowing down entries. A single X button in the search bar clears all selected tags and the search input, returning to an unfiltered view.

https://cosine.sh/stud0709/oms4web/task/09chq9moajai
https://cosine.sh/gh/stud0709/oms4web/pull/20
Author: Yuriy Dzhenyeyev