### PR TITLE
Fix URL truncation in PasswordCard to prevent overflow on Android

### DIFF
--- a/src/components/PasswordCard.tsx
+++ b/src/components/PasswordCard.tsx
@@ -198,9 +198,9 @@ export function PasswordCard({
                   target="_blank"
                   rel="noopener noreferrer"
                   title={entryToDisplay.url}
-                  className="text-sm text-muted-foreground hover:text-primary flex flex-1 items-center gap-1 transition-colors min-w-0 overflow-hidden"
+                  className="text-sm text-muted-foreground hover:text-primary flex flex-1 items-center gap-1 transition-colors min-w-0 max-w-full overflow-hidden"
                 >
-                  <span className="truncate flex-1 min-w-0">{entryToDisplay.url}</span>
+                  <span className="block truncate flex-1 min-w-0">{entryToDisplay.url}</span>
                   <ExternalLink className="h-3 w-3 flex-shrink-0" />
                 </a>
                 {!referenceMode && (
@@ -358,9 +358,9 @@ export function PasswordCard({
                         href={toExternalUrl(field.value)}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 hover:text-primary transition-colors min-w-0 max-w-full"
+                        className="inline-flex items-center gap-1 hover:text-primary transition-colors min-w-0 max-w-full overflow-hidden"
                       >
-                        <span className="truncate flex-1 min-w-0">{field.value}</span>
+                        <span className="block truncate flex-1 min-w-0">{field.value}</span>
                         <ExternalLink className="h-3 w-3 flex-shrink-0" />
                       </a>
                     )

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -693,7 +693,7 @@ const Index = () => {
             {filteredEntries.map((entry, index) => (
               <div
                 key={entry.id}
-                className="animate-slide-up"
+                className="animate-slide-up min-w-0"
                 style={{ animationDelay: `${index * 50}ms` }}
               >
                 <PasswordCard


### PR DESCRIPTION
Problem: On Android, long URLs in the password card were not truncated, causing the card to expand beyond the screen width. On Windows, URLs remained properly truncated within the card.

What I changed:
- PasswordCard.tsx:
  - URL link now uses max-w-full on the anchor to constrain width inside the card.
  - The URL text spans were changed from truncate flex-1 min-w-0 to block truncate flex-1 min-w-0 to enforce truncation within the available space.
  - The same adjustments were applied to other URL-like field values to ensure consistent truncation behavior.
- Index.tsx:
  - Added min-w-0 to the animated row containers to allow proper shrinking of flex children and prevent overflow.

Why it fixes the issue:
- The added max-w-full and block-level truncation ensure long URLs do not overflow the password card on Android devices, keeping the layout within screen bounds. The modifications retain the truncation behavior on Windows as before.

How to verify:
- Run the app on an Android device or emulator and open a password card with a long URL. The URL should truncate with ellipsis and stay within the card width.
- Confirm the same URL still truncates correctly on Windows.


https://cosine.sh/stud0709/oms4web/task/ys4bxvnvjdo3
https://cosine.sh/gh/stud0709/oms4web/pull/21
Author: Yuriy Dzhenyeyev