### PR TITLE
Add Manage Tags dialog with rename and delete across entries

### DIFF
--- a/src/components/ManageTagsDialog.tsx
+++ b/src/components/ManageTagsDialog.tsx
@@ -1,0 +1,154 @@
+import { useMemo, useState } from 'react';
+import { Tags, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { normalizeTag } from '@/lib/tagUtils';
+
+interface ManageTagsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tags: string[];
+  onRename: (from: string, to: string) => void;
+  onDelete: (tag: string) => void;
+}
+
+export function ManageTagsDialog({
+  open,
+  onOpenChange,
+  tags,
+  onRename,
+  onDelete,
+}: ManageTagsDialogProps) {
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [confirmDeleteTag, setConfirmDeleteTag] = useState<string | null>(null);
+
+  const sortedTags = useMemo(() => [...tags].sort((a, b) => a.localeCompare(b)), [tags]);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    onOpenChange(nextOpen);
+    if (nextOpen) {
+      setDrafts(Object.fromEntries(tags.map(t => [t, t])));
+    } else {
+      setConfirmDeleteTag(null);
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-hidden">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Tags className="h-4 w-4" />
+              Manage tags
+            </DialogTitle>
+          </DialogHeader>
+
+          {sortedTags.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No tags yet.</p>
+          ) : (
+            <ScrollArea className="-mx-6 px-6 max-h-[60vh]">
+              <div className="space-y-3">
+                {sortedTags.map(tag => {
+                  const rawDraft = drafts[tag] ?? tag;
+                  const normalized = normalizeTag(rawDraft);
+                  const canRename = normalized.length > 0 && normalized !== tag;
+
+                  return (
+                    <div key={tag} className="flex items-center gap-2">
+                      <div className="flex-1">
+                        <Input
+                          value={rawDraft}
+                          onChange={(e) => setDrafts(prev => ({ ...prev, [tag]: e.target.value }))}
+                          onKeyDown={(e) => {
+                            if (e.key !== 'Enter') return;
+                            e.preventDefault();
+                            if (canRename) {
+                              onRename(tag, normalized);
+                              setDrafts(prev => ({ ...prev, [normalized]: normalized }));
+                            }
+                          }}
+                          placeholder={tag}
+                        />
+                        {rawDraft && rawDraft !== normalized && (
+                          <p className="text-xs text-muted-foreground mt-1">Will be saved as #{normalized}</p>
+                        )}
+                      </div>
+
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={!canRename}
+                        onClick={() => onRename(tag, normalized)}
+                      >
+                        Rename
+                      </Button>
+
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="text-destructive hover:text-destructive"
+                        title="Delete tag"
+                        onClick={() => setConfirmDeleteTag(tag)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  );
+                })}
+              </div>
+            </ScrollArea>
+          )}
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={!!confirmDeleteTag} onOpenChange={(open) => !open && setConfirmDeleteTag(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete tag</AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirmDeleteTag ? `This removes #${confirmDeleteTag} from all entries.` : ''}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setConfirmDeleteTag(null)}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (confirmDeleteTag) onDelete(confirmDeleteTag);
+                setConfirmDeleteTag(null);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/hooks/useEncryptedVault.ts
+++ b/src/hooks/useEncryptedVault.ts
@@ -588,6 +588,50 @@ startWithEmptyVault();
     return Array.from(tags).sort();
   }, [vaultData.entries]);
 
+  const renameTag = useCallback((from: string, to: string) => {
+    if (!from || !to || from === to) return;
+
+    setEntries(prev => prev.map(entry => {
+      if (!entry.hashtags.includes(from)) return entry;
+
+      const { history, ...entryData } = entry;
+      const historyEntry: PasswordEntryHistoryItem = {
+        timestamp: new Date(),
+        data: entryData,
+      };
+
+      const hashtags = Array.from(new Set(entry.hashtags.map(t => (t === from ? to : t))));
+
+      return {
+        ...entry,
+        hashtags,
+        updatedAt: new Date(),
+        history: [historyEntry, ...(history ?? [])],
+      };
+    }));
+  }, [setEntries]);
+
+  const deleteTagEverywhere = useCallback((tag: string) => {
+    if (!tag) return;
+
+    setEntries(prev => prev.map(entry => {
+      if (!entry.hashtags.includes(tag)) return entry;
+
+      const { history, ...entryData } = entry;
+      const historyEntry: PasswordEntryHistoryItem = {
+        timestamp: new Date(),
+        data: entryData,
+      };
+
+      return {
+        ...entry,
+        hashtags: entry.hashtags.filter(t => t !== tag),
+        updatedAt: new Date(),
+        history: [historyEntry, ...(history ?? [])],
+      };
+    }));
+  }, [setEntries]);
+
   const importEntries = useCallback(async (data: VaultData) => {
     await updateSha256(true);
     setVaultData(data);
@@ -684,6 +728,8 @@ startWithEmptyVault();
     updateEntry,
     deleteEntry,
     getAllHashtags,
+    renameTag,
+    deleteTagEverywhere,
     importEntries,
     mergeEntries,
     exportData,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,7 +13,8 @@ import {
   Loader2,
   LockKeyhole,
   ExternalLink,
-  GitMerge
+  GitMerge,
+  Tags
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
@@ -28,6 +29,7 @@ import { PasswordForm } from '@/components/PasswordForm';
 import { SearchBar } from '@/components/SearchBar';
 import { HashtagFilter } from '@/components/HashtagFilter';
 import { SettingsDialog } from '@/components/SettingsDialog';
+import { ManageTagsDialog } from '@/components/ManageTagsDialog';
 import { DecryptQrDialog } from '@/components/DecryptQrDialog';
 import { PinUnlockDialog } from '@/components/PinUnlockDialog';
 import { CustomFieldProtection, PasswordEntry, VaultData } from '@/types/types';
@@ -59,6 +61,8 @@ const Index = () => {
     updateEntry,
     deleteEntry,
     getAllHashtags,
+    renameTag,
+    deleteTagEverywhere,
     importEntries,
     mergeEntries,
     exportData,
@@ -84,6 +88,7 @@ const Index = () => {
   const [mergeCandidateData, setMergeCandidateData] = useState<VaultData | null>(null);
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
   const [mergeTag, setMergeTag] = useState('');
+  const [manageTagsOpen, setManageTagsOpen] = useState(false);
   const allTags = getAllHashtags();
 
   const {
@@ -611,6 +616,32 @@ const Index = () => {
     });
   };
 
+  const handleRenameTag = (from: string, to: string) => {
+    const normalized = normalizeTag(to);
+    if (!normalized || normalized === from) return;
+
+    renameTag(from, normalized);
+
+    setSelectedTags(prev => {
+      if (!prev.has(from)) return prev;
+      const next = new Set(prev);
+      next.delete(from);
+      next.add(normalized);
+      return next;
+    });
+  };
+
+  const handleDeleteTag = (tag: string) => {
+    deleteTagEverywhere(tag);
+
+    setSelectedTags(prev => {
+      if (!prev.has(tag)) return prev;
+      const next = new Set(prev);
+      next.delete(tag);
+      return next;
+    });
+  };
+
   return (
     <div className="h-dvh flex flex-col overflow-hidden">
       {/* Header */}
@@ -638,6 +669,10 @@ const Index = () => {
                 </Button>
                 <Button className="shrink-0" variant="outline" size="icon" onClick={() => mergeFileInputRef.current?.click()} title="Merge">
                   <GitMerge className="h-4 w-4" />
+                </Button>
+                <Button className="shrink-0 gap-2" variant="outline" size="sm" onClick={() => setManageTagsOpen(true)}>
+                  <Tags className="h-4 w-4" />
+                  Manage tags
                 </Button>
                 {//"Lock workspace" button to be shown only if workspace protection activated
                   vaultData.settings.workspaceProtection !== 'none' && (
@@ -760,6 +795,14 @@ const Index = () => {
         onSave={handleSave}
         existingTags={allTags}
         settings={vaultData.settings}
+      />
+
+      <ManageTagsDialog
+        open={manageTagsOpen}
+        onOpenChange={setManageTagsOpen}
+        tags={allTags}
+        onRename={handleRenameTag}
+        onDelete={handleDeleteTag}
       />
 
       <AlertDialog open={mergeDialogOpen} onOpenChange={(open) => {


### PR DESCRIPTION
Introduce a new ManageTagsDialog component and wire it into the index page to manage tags:

- New ManageTagsDialog (src/components/ManageTagsDialog.tsx): allows renaming tags and deleting tags across all entries. Renaming updates entries that include the tag, preserves history, and updates the tag in the UI. Deleting removes the tag from every entry and records a history entry. Deletion is confirmed via a confirmation dialog.
- Hook support (src/hooks/useEncryptedVault.ts): added renameTag(from, to) and deleteTagEverywhere(tag) to apply changes across all entries and keep history in sync.
- UI wiring (src/pages/Index.tsx): added a header button "Manage tags" with a Tags icon to open the dialog. Passed handlers and current tags to the dialog; synchronized selection when tags are renamed or deleted.

Key details:
- Tags are sorted in the dialog for easier navigation.
- Renaming uses normalization via normalizeTag and only enables Rename when a valid difference exists.
- Deleting a tag only affects entries containing it and prompts for confirmation before applying.
- Selected filter state updates to reflect renamed or removed tags.

This PR solves the issue of managing tags by providing a centralized UI to rename and remove tags across all entries, ensuring data consistency and history tracking.

https://cosine.sh/stud0709/oms4web/task/z28hyswp72ei
https://cosine.sh/gh/stud0709/oms4web/pull/24
Author: Yuriy Dzhenyeyev