### PR TITLE
Index: Make custom fields searchable in entries search

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -135,15 +135,26 @@ const Index = () => {
 
     const selectedTagsArr = Array.from(selectedTags);
 
+    const searchLower = search.toLowerCase();
+
     return vaultData.entries
       .map(e => applyRef(e))
       .filter(entry => {
+        const matchesCustomFields = entry.customFields?.some(field => {
+          if (field.label.toLowerCase().includes(searchLower)) return true;
+
+          // For encrypted custom fields we can't search by plaintext value.
+          if (!field.value || field.value.startsWith(OMS_PREFIX)) return false;
+          return field.value.toLowerCase().includes(searchLower);
+        }) ?? false;
+
         const matchesSearch = !search ||
-          entry.title.toLowerCase().includes(search.toLowerCase()) ||
-          entry.username.toLowerCase().includes(search.toLowerCase()) ||
-          entry.url.toLowerCase().includes(search.toLowerCase()) ||
-          entry.notes.toLowerCase().includes(search.toLowerCase()) ||
-          entry.hashtags.some(tag => tag.includes(search.toLowerCase()));
+          entry.title.toLowerCase().includes(searchLower) ||
+          entry.username.toLowerCase().includes(searchLower) ||
+          entry.url.toLowerCase().includes(searchLower) ||
+          entry.notes.toLowerCase().includes(searchLower) ||
+          entry.hashtags.some(tag => tag.includes(searchLower)) ||
+          matchesCustomFields;
 
         const matchesTags = selectedTagsArr.length === 0 || selectedTagsArr.every(tag => entry.hashtags.includes(tag));
 


### PR DESCRIPTION
Extend the search in src/pages/Index.tsx to include custom fields. The code now searches within entry.customFields by field label (case-insensitive) and, where possible, the plaintext field value. Encrypted or missing values are not searchable to preserve privacy.

Key changes:
- Introduced searchLower = search.toLowerCase() for consistent case-insensitive comparisons.
- Added matchesCustomFields to check if any custom field label matches the query or if a non-encrypted value contains the query.
- Included matchesCustomFields in the overall matchesSearch condition so custom fields participate in filtering.

Rationale:
- Enables users to find entries by custom field labels and plaintext values, improving discoverability while respecting encrypted data (encrypted values remain non-searchable).

Notes:
- No UX changes; existing search across title, username, url, notes, and hashtags remains intact.

https://cosine.sh/stud0709/oms4web/task/zxypmpc6lh0b
https://cosine.sh/gh/stud0709/oms4web/pull/26
Author: Yuriy Dzhenyeyev