### PR TITLE
Add tooltips to header and icon-only buttons in PasswordCard and PasswordForm

### DIFF
--- a/src/components/PasswordCard.tsx
+++ b/src/components/PasswordCard.tsx
@@ -18,6 +18,7 @@ import {
   MapPin
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import {
   Card,
   CardContent,
@@ -202,7 +203,8 @@ export function PasswordCard({
   };
 
   return (
-    <Card className="group w-full min-w-0 overflow-hidden transition-all duration-300 hover:shadow-glow hover:border-primary/30">
+    <TooltipProvider>
+      <Card className="group w-full min-w-0 overflow-hidden transition-all duration-300 hover:shadow-glow hover:border-primary/30">
       <CardHeader className="pb-3">
         <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4">
           <div className="flex-1 min-w-0">
@@ -220,9 +222,14 @@ export function PasswordCard({
                   <ExternalLink className="h-3 w-3 flex-shrink-0" />
                 </a>
                 {!referenceMode && (
-                  <Button variant="ghost" size="icon" className="h-6 w-6 flex-shrink-0" onClick={() => copyToClipboard(entryToDisplay.url!, 'URL')}>
-                    <Copy className="h-3 w-3" />
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button variant="ghost" size="icon" className="h-6 w-6 flex-shrink-0" onClick={() => copyToClipboard(entryToDisplay.url!, 'URL')}>
+                        <Copy className="h-3 w-3" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Copy URL</TooltipContent>
+                  </Tooltip>
                 )}
                 {referenceMode && (
                   <>
@@ -242,15 +249,25 @@ export function PasswordCard({
           <div className="flex items-center gap-1 self-end sm:self-start">
             {!referenceMode && (
               <div className={`flex gap-1 ${env.android ? 'opacity-100' : "opacity-0 group-hover:opacity-100 transition-opacity"}`}>
-                <Button variant="ghost" size="icon" onClick={() => onEdit(entry)}>
-                  <Pencil className="h-4 w-4" />
-                </Button>
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive">
-                      <Trash2 className="h-4 w-4" />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button variant="ghost" size="icon" onClick={() => onEdit(entry)}>
+                      <Pencil className="h-4 w-4" />
                     </Button>
-                  </AlertDialogTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>Edit</TooltipContent>
+                </Tooltip>
+                <AlertDialog>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <AlertDialogTrigger asChild>
+                        <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive">
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </AlertDialogTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>Delete</TooltipContent>
+                  </Tooltip>
                   <AlertDialogContent>
                     <AlertDialogHeader>
                       <AlertDialogTitle>{isDeleted ? 'Permanently Delete Entry' : 'Delete Entry'}</AlertDialogTitle>
@@ -293,9 +310,14 @@ export function PasswordCard({
             </div>
             <div className="flex gap-1 flex-shrink-0">
               {!referenceMode && (
-                <Button variant="ghost" size="icon" onClick={() => copyToClipboard(entryToDisplay.username, 'Username')}>
-                  <Copy className="h-4 w-4" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button variant="ghost" size="icon" onClick={() => copyToClipboard(entryToDisplay.username, 'Username')}>
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Copy username</TooltipContent>
+                </Tooltip>
               )}
               {referenceMode && (
                 <>
@@ -333,15 +355,25 @@ export function PasswordCard({
                   </Button>)}
                   {env.android && (
                     <>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => handleIntent(entryToDisplay.password)}>
-                        <Webhook className="h-4 w-4" />
-                      </Button>
-                      <Button variant="ghost" size="icon" onClick={() => copyToClipboard(entryToDisplay.password, 'Password')}>
-                        <Copy className="h-4 w-4" />
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleIntent(entryToDisplay.password)}>
+                            <Webhook className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Open in app</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button variant="ghost" size="icon" onClick={() => copyToClipboard(entryToDisplay.password, 'Password')}>
+                            <Copy className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Copy password</TooltipContent>
+                      </Tooltip>
                     </>
                   )}
                 </>)}
@@ -397,23 +429,38 @@ export function PasswordCard({
                           <QrCode className="h-4 w-4" />
                         </Button>)}
                       {env.android && (
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => handleIntent(field.value)}>
-                          <Webhook className="h-4 w-4" />
-                        </Button>)}
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => handleIntent(field.value)}>
+                              <Webhook className="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Open in app</TooltipContent>
+                        </Tooltip>)}
                     </>
                   )}
                   {field.protection === 'secret' && (
-                    <Button variant="ghost" size="icon" onClick={() => toggleFieldVisibility(field.id)}>
-                      {visibleFields.has(field.id) ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                    </Button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button variant="ghost" size="icon" onClick={() => toggleFieldVisibility(field.id)}>
+                          {visibleFields.has(field.id) ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>{visibleFields.has(field.id) ? 'Hide' : 'Show'}</TooltipContent>
+                    </Tooltip>
                   )}
                   {(!isAirGapField(field.value) || env.android) && (
-                    <Button variant="ghost" size="icon" onClick={() => copyToClipboard(field.value, field.label)}>
-                      <Copy className="h-4 w-4" />
-                    </Button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button variant="ghost" size="icon" onClick={() => copyToClipboard(field.value, field.label)}>
+                          <Copy className="h-4 w-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Copy</TooltipContent>
+                    </Tooltip>
                   )}
                 </>
               )}
@@ -485,5 +532,6 @@ export function PasswordCard({
         password={qrDialogValue || ''}
       />
     </Card>
+    </TooltipProvider>
   );
 }

--- a/src/components/PasswordForm.tsx
+++ b/src/components/PasswordForm.tsx
@@ -264,6 +264,7 @@ export function PasswordForm({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        <TooltipProvider>
         <DialogHeader>
         <div className="flex flex-wrap items-center gap-2">
           <div className="flex flex-wrap items-center gap-2">
@@ -275,9 +276,14 @@ export function PasswordForm({
           {entry && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" title="Entry history">
-                  <History className="h-4 w-4" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button variant="ghost" size="icon">
+                      <History className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>History</TooltipContent>
+                </Tooltip>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-64">
                 <DropdownMenuLabel>History</DropdownMenuLabel>
@@ -324,9 +330,14 @@ export function PasswordForm({
                 className="flex-1"
               />
               {isReadOnly && title && (
-                <Button type="button" variant="ghost" size="icon" onClick={() => copyToClipboard(title)}>
-                  <Copy className="h-4 w-4" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button type="button" variant="ghost" size="icon" onClick={() => copyToClipboard(title)}>
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Copy title</TooltipContent>
+                </Tooltip>
               )}
             </div>
           </div>
@@ -343,9 +354,14 @@ export function PasswordForm({
                 className="flex-1"
               />
               {isReadOnly && url && (
-                <Button type="button" variant="ghost" size="icon" onClick={() => copyToClipboard(url)}>
-                  <Copy className="h-4 w-4" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button type="button" variant="ghost" size="icon" onClick={() => copyToClipboard(url)}>
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Copy URL</TooltipContent>
+                </Tooltip>
               )}
             </div>
           </div>
@@ -362,9 +378,14 @@ export function PasswordForm({
                 className="flex-1"
               />
               {isReadOnly && username && (
-                <Button type="button" variant="ghost" size="icon" onClick={() => copyToClipboard(username)}>
-                  <Copy className="h-4 w-4" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button type="button" variant="ghost" size="icon" onClick={() => copyToClipboard(username)}>
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Copy username</TooltipContent>
+                </Tooltip>
               )}
             </div>
           </div>
@@ -405,19 +426,29 @@ export function PasswordForm({
                   </TooltipProvider>
                 )}
                 {isReadOnly && password && !passwordReadonly && (
-                  <Button type="button" variant="ghost" size="icon" onClick={() => copyToClipboard(password)}>
-                    <Copy className="h-4 w-4" />
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button type="button" variant="ghost" size="icon" onClick={() => copyToClipboard(password)}>
+                        <Copy className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Copy password</TooltipContent>
+                  </Tooltip>
                 )}
                 {!passwordReadonly && !isReadOnly && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => setShowPassword(!showPassword)}
-                  >
-                    {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setShowPassword(!showPassword)}
+                      >
+                        {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{showPassword ? 'Hide password' : 'Show password'}</TooltipContent>
+                  </Tooltip>
                 )}
               </div>
               {!isReadOnly && settings.encryptionEnabled && <PasswordGenerator onGenerate={handlePasswordGenerated} />}
@@ -428,9 +459,14 @@ export function PasswordForm({
             <div className="flex items-center justify-between">
               <Label>Hashtags</Label>
               {isReadOnly && hashtags.length > 0 && (
-                <Button type="button" variant="ghost" size="icon" onClick={() => copyToClipboard(hashtags.join(', '))}>
-                  <Copy className="h-4 w-4" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button type="button" variant="ghost" size="icon" onClick={() => copyToClipboard(hashtags.join(', '))}>
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Copy hashtags</TooltipContent>
+                </Tooltip>
               )}
             </div>
             <div className="flex flex-wrap gap-1.5 mb-2">
@@ -496,9 +532,14 @@ export function PasswordForm({
                 className="flex-1"
               />
               {isReadOnly && notes && (
-                <Button type="button" variant="ghost" size="icon" onClick={() => copyToClipboard(notes)}>
-                  <Copy className="h-4 w-4" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button type="button" variant="ghost" size="icon" onClick={() => copyToClipboard(notes)}>
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Copy notes</TooltipContent>
+                </Tooltip>
               )}
             </div>
           </div>
@@ -533,9 +574,14 @@ export function PasswordForm({
                       disabled={isReadOnly || field.readonly}
                     />
                     {isReadOnly && field.value && !field.readonly && (
-                      <Button type="button" variant="ghost" size="icon" className="h-8 w-8" onClick={() => copyToClipboard(field.value)}>
-                        <Copy className="h-4 w-4" />
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button type="button" variant="ghost" size="icon" className="h-8 w-8" onClick={() => copyToClipboard(field.value)}>
+                            <Copy className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Copy</TooltipContent>
+                      </Tooltip>
                     )}
                     {field.readonly && (
                       <TooltipProvider>
@@ -602,15 +648,20 @@ export function PasswordForm({
                   </div>
                 </div>
                 {!isReadOnly && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => removeCustomField(field.id)}
-                    className="text-destructive hover:text-destructive"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => removeCustomField(field.id)}
+                        className="text-destructive hover:text-destructive"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Remove field</TooltipContent>
+                  </Tooltip>
                 )}
               </div>
             ))}
@@ -625,6 +676,7 @@ export function PasswordForm({
             </Button>
           </DialogFooter>
         </form>
+      </TooltipProvider>
       </DialogContent>
     </Dialog>
   );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -17,6 +17,7 @@ import {
   Tags
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import {
   downloadVault,
@@ -669,47 +670,84 @@ const Index = () => {
               </div>
             </div>
             <ScrollArea className="flex-1">
-              <div className="flex items-center gap-2 flex-nowrap justify-end pr-1">
-                <Button className="shrink-0" variant="outline" size="icon" onClick={() => setFormOpen(true)}>
-                  <Plus className="h-4 w-4" />
-                </Button>
-                <Button className="shrink-0" variant="outline" size="icon" onClick={handleExport} title="Export">
-                  <Download className="h-4 w-4" />
-                </Button>
-                <Button className="shrink-0" variant="outline" size="icon" onClick={() => fileInputRef.current?.click()} title="Import">
-                  <Upload className="h-4 w-4" />
-                </Button>
-                <Button className="shrink-0" variant="outline" size="icon" onClick={() => mergeFileInputRef.current?.click()} title="Merge">
-                  <GitMerge className="h-4 w-4" />
-                </Button>
-                <Button className="shrink-0 gap-2" variant="outline" size="sm" onClick={() => setManageTagsOpen(true)}>
-                  <Tags className="h-4 w-4" />
-                </Button>
-                {//"Lock workspace" button to be shown only if workspace protection activated
-                  vaultData.settings.workspaceProtection !== 'none' && (
-                    <Button className="shrink-0" variant="outline" size="icon" onClick={lockVault} title="Lock Workspace">
-                      <LockKeyhole className="h-4 w-4" />
-                    </Button>
-                  )}
-                <SettingsDialog
-                  settings={vaultData.settings}
-                  onSaveSettings={updateSettings}
-                />
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".json,.oms00"
-                  className="hidden"
-                  onChange={handleImport}
-                />
-                <input
-                  ref={mergeFileInputRef}
-                  type="file"
-                  accept=".json,.oms00,.xml"
-                  className="hidden"
-                  onChange={handleMerge}
-                />
-              </div>
+              <TooltipProvider>
+                <div className="flex items-center gap-2 flex-nowrap justify-end pr-1">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button className="shrink-0" variant="outline" size="icon" onClick={() => setFormOpen(true)}>
+                        <Plus className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>New entry</TooltipContent>
+                  </Tooltip>
+
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button className="shrink-0" variant="outline" size="icon" onClick={handleExport}>
+                        <Download className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Export</TooltipContent>
+                  </Tooltip>
+
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button className="shrink-0" variant="outline" size="icon" onClick={() => fileInputRef.current?.click()}>
+                        <Upload className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Import</TooltipContent>
+                  </Tooltip>
+
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button className="shrink-0" variant="outline" size="icon" onClick={() => mergeFileInputRef.current?.click()}>
+                        <GitMerge className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Merge</TooltipContent>
+                  </Tooltip>
+
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button className="shrink-0 gap-2" variant="outline" size="sm" onClick={() => setManageTagsOpen(true)}>
+                        <Tags className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Manage tags</TooltipContent>
+                  </Tooltip>
+
+                  {//"Lock workspace" button to be shown only if workspace protection activated
+                    vaultData.settings.workspaceProtection !== 'none' && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button className="shrink-0" variant="outline" size="icon" onClick={lockVault}>
+                            <LockKeyhole className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Lock workspace</TooltipContent>
+                      </Tooltip>
+                    )}
+                  <SettingsDialog
+                    settings={vaultData.settings}
+                    onSaveSettings={updateSettings}
+                  />
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".json,.oms00"
+                    className="hidden"
+                    onChange={handleImport}
+                  />
+                  <input
+                    ref={mergeFileInputRef}
+                    type="file"
+                    accept=".json,.oms00,.xml"
+                    className="hidden"
+                    onChange={handleMerge}
+                  />
+                </div>
+              </TooltipProvider>
               <ScrollBar orientation="horizontal" />
             </ScrollArea>
           </div>


### PR DESCRIPTION
This PR adds contextual tooltips to all icon-only buttons across the header, PasswordCard, and PasswordForm to improve discoverability and accessibility.

What changed:
- Added TooltipProvider where tooltips are used and wrapped relevant button groups with Tooltip, TooltipTrigger, and TooltipContent.
- PasswordCard.tsx
  - Copy URL, Edit, Delete, Copy username, Copy password, Open in app, Show/Hide password, Copy fields, Remove field, etc., now display tooltips with descriptive labels (e.g., Copy URL, Edit, Delete, Copy username, Copy password, Open in app, Show/Hide, Copy, Remove field).
  - Included tooltips for hashtags, notes, and field values where applicable.
- PasswordForm.tsx
  - Tooltips for History, Copy title/url/username/password, Show password, Copy notes, Copy hashtags, Copy password, and Remove field actions.
  - Wrapped Dialog content with TooltipProvider to ensure proper rendering of all tooltips.
- Index.tsx (header)
  - All icon buttons (New entry, Export, Import, Merge, Manage tags, Lock workspace) now show tooltips with concise labels.
  - Wrapped header action container in TooltipProvider.

Impact:
- No change to existing behaviors; tooltips are purely additive and enhance user guidance for icon-only actions.
- Short, consistent labels help users understand what each action does without having to hover or guess.

https://cosine.sh/stud0709/oms4web/task/n408h2dpg23y
https://cosine.sh/gh/stud0709/oms4web/pull/27
Author: Yuriy Dzhenyeyev