### PR TITLE
Add bulk permanent deletion for entries tagged 'deleted' with confirmation dialog

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -258,6 +258,23 @@ const Index = () => {
     }
   };
 
+  const [purgeDeletedOpen, setPurgeDeletedOpen] = useState(false);
+
+  const deletedEntryIds = useMemo(
+    () => vaultData.entries.filter(e => e.hashtags.includes(DELETED_TAG)).map(e => e.id),
+    [vaultData.entries]
+  );
+
+  const permanentlyDeleteAllDeleted = () => {
+    for (const id of deletedEntryIds) {
+      deleteEntry(id);
+    }
+    setPurgeDeletedOpen(false);
+    if (deletedEntryIds.length > 0) {
+      toast({ title: 'Deleted', description: `${deletedEntryIds.length} entries permanently deleted.` });
+    }
+  };
+
   const handleSearchChange = (value: string) => {
     if (value.startsWith(OMS4WEB_REF)) {
       //clear tag selection
@@ -802,6 +819,42 @@ const Index = () => {
                 onToggleTag={handleToggleTag}
                 onClear={() => setSelectedTags(new Set())}
               />
+
+              {selectedTags.has(DELETED_TAG) && (
+                <div className="mt-3">
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => setPurgeDeletedOpen(true)}
+                    disabled={deletedEntryIds.length === 0}
+                  >
+                    Permanently delete all
+                  </Button>
+
+                  <AlertDialog open={purgeDeletedOpen} onOpenChange={setPurgeDeletedOpen}>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Permanently delete all</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          {deletedEntryIds.length === 0
+                            ? 'There are no deleted entries.'
+                            : `Are you sure you want to permanently delete ${deletedEntryIds.length} deleted ${deletedEntryIds.length === 1 ? 'entry' : 'entries'}? This action cannot be undone.`}
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={permanentlyDeleteAllDeleted}
+                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                          disabled={deletedEntryIds.length === 0}
+                        >
+                          Delete permanently
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </div>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
This patch adds a new bulk deletion flow for entries tagged as deleted.

- When the user selects the DELETED_TAG, a new red button labeled “Permanently delete all” appears below the hashtag filter in the index header.
- Clicking the button opens a confirmation dialog (reusing the existing AlertDialog pattern).
- Confirming deletes all entries that have the deleted tag by calling deleteEntry for each matching ID, then closes the dialog and shows a toast with the count of permanently deleted entries.
- The button is disabled when there are no deleted-tag entries.
- Implementation details:
  - Added purgeDeletedOpen state to control the confirmation dialog.
  - Computed deletedEntryIds with useMemo by filtering vaultData.entries for the DELETED_TAG.
  - Implemented permanentlyDeleteAllDeleted to perform the deletions and user feedback.
  - Rendered the new UI block conditionally when the deleted tag is selected, following the existing PasswordCard deletion UX for consistency.

https://cosine.sh/stud0709/oms4web/task/p33o4i363qbb
https://cosine.sh/gh/stud0709/oms4web/pull/33
Author: Yuriy Dzhenyeyev