### PR TITLE
Parse KeePass XML entries using direct children to prevent history overwriting main entry

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -414,7 +414,11 @@ const Index = () => {
       return child?.textContent ?? '';
     };
 
+    const getDirectChildren = (el: Element, tagName: string) =>
+      Array.from(el.children).filter(child => child.tagName === tagName);
 
+    const getDirectChild = (el: Element, tagName: string) =>
+      getDirectChildren(el, tagName)[0] ?? null;
 
     const parseBool = (v: string | null) => v?.toLowerCase() === 'true';
 
@@ -450,7 +454,9 @@ const Index = () => {
     };
 
     const parseEntryData = async (entryEl: Element, entryId: string, extraHashtags: string[] = []) => {
-      const stringEls = Array.from(entryEl.getElementsByTagName('String'));
+      // Important: Entry contains nested <History><Entry>...</Entry></History>.
+      // We must only parse *direct* children here, otherwise history fields may overwrite the main entry.
+      const stringEls = getDirectChildren(entryEl, 'String');
 
       const kv = new Map<string, { value: string; protectInMemory: boolean }>();
       for (const stringEl of stringEls) {
@@ -468,7 +474,8 @@ const Index = () => {
       const notes = kv.get('Notes')?.value ?? '';
       const passwordRes = await maybeEncryptProtected(kv.get('Password')?.value ?? '', kv.get('Password')?.protectInMemory ?? false);
 
-      const tagsRaw = getChildText(entryEl, 'Tags') || kv.get('Tags')?.value || '';
+      const tagsEl = getDirectChild(entryEl, 'Tags');
+      const tagsRaw = (tagsEl?.textContent ?? '') || kv.get('Tags')?.value || '';
       const hashtags = Array.from(new Set([
         ...tagsRaw
           .split(/[,;\s]+/)
@@ -477,7 +484,7 @@ const Index = () => {
         ...extraHashtags.map(normalizeTag).filter(Boolean),
       ]));
 
-      const timesEl = entryEl.getElementsByTagName('Times')[0];
+      const timesEl = getDirectChild(entryEl, 'Times');
       const createdAtStr = timesEl ? getChildText(timesEl, 'CreationTime') : '';
       const updatedAtStr = timesEl ? getChildText(timesEl, 'LastModificationTime') : '';
       const createdAt = createdAtStr ? new Date(createdAtStr) : new Date();


### PR DESCRIPTION
This change fixes an issue where the main entry data could be overwritten by nested history entries when parsing KeePass XML (KDBX XML) files.

What I changed:
- Added helper functions getDirectChildren and getDirectChild in src/pages/Index.tsx to select only direct child elements by tag name.
- Updated parseEntryData to use direct children for String, Tags, and Times elements instead of querying the whole subtree (which included history entries).

Why:
- In KeePass XML, an Entry contains a History element with nested Entries. Previously parsing used methods like getElementsByTagName, which pulled in descendant nodes from History and could overwrite the main entry’s data with historical values. This caused the main entry to reflect older values (e.g., OLD PASSWORD) instead of the primary values (e.g., NEW PASSWORD).

Impact:
- The main entry’s data (such as Password, Title, UserName) now correctly reflect the primary entry, not the latest history entry.
- History entries remain accessible through their dedicated History structure, but they won’t interfere with parsing of the main entry fields.

How to test:
- Use the provided sample XML (with NEW PASSWORD as the main entry Password and OLD/VERY OLD passwords in History).
- Parse the entry and verify that the Password extracted for the main entry is NEW PASSWORD, not OLD or VERY OLD.
- Validate that other main-entry fields remain unchanged by history data.

If you have tests around XML parsing, this should be covered by adjusting tests to ensure only direct children are considered when extracting String, Tags, and Times.

https://cosine.sh/stud0709/oms4web/task/ep9fq52pa85s
https://cosine.sh/gh/stud0709/oms4web/pull/34
Author: Yuriy Dzhenyeyev