### PR TITLE
Call onAccess for newly created password entry and support async onSave

### DIFF
--- a/src/components/PasswordForm.tsx
+++ b/src/components/PasswordForm.tsx
@@ -54,7 +54,7 @@ interface PasswordFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   entry?: PasswordEntry | null;
-  onSave: (entry: Omit<PasswordEntry, 'id' | 'createdAt' | 'updatedAt' | 'history'>) => void;
+  onSave: (entry: Omit<PasswordEntry, 'id' | 'createdAt' | 'updatedAt' | 'history'>) => void | Promise<void>;
   existingTags: string[];
   settings: AppSettings;
 }
@@ -240,7 +240,7 @@ export function PasswordForm({
             return field;
           }));
 
-      onSave({
+      await onSave({
         title: title.trim() || 'Untitled',
         username,
         password: finalPassword,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -293,11 +293,12 @@ const Index = () => {
     return ordered;
   }, [allTags, filteredEntries, selectedTags]);
 
-  const handleSave = (data: Omit<PasswordEntry, 'id' | 'createdAt' | 'updatedAt' | 'history'>) => {
+  const handleSave = async (data: Omit<PasswordEntry, 'id' | 'createdAt' | 'updatedAt' | 'history'>) => {
     if (editingEntry) {
       updateEntry(editingEntry.id, data);
     } else {
-      addEntry(data);
+      const newEntry = addEntry(data);
+      await onAccess(newEntry.id);
       // Ensure the newly created entry is visible immediately
       setSearch('');
       setSelectedTags(new Set());


### PR DESCRIPTION
This PR updates the save flow to properly handle async onSave and to open the newly created entry immediately.

What changed:
- PasswordForm.tsx
  - Made onSave return void or Promise<void> to support async operations.
  - Updated the save path to await onSave({...}) so async handlers complete before proceeding.

- Index.tsx
  - Made handleSave async to accommodate awaiting async operations.
  - In the create-entry path, after addEntry(data), the code now awaits onAccess(newEntry.id) to open/select the new entry.
  - Retains existing behavior for editing entries; after save, it clears search and resets tag selection to show the latest state.

Why:
- Ensures onAccess is called for newly created entries and supports async save handlers, providing a smoother UX by immediately focusing or opening the new entry once created.

https://cosine.sh/stud0709/oms4web/task/okgye1l4la64
https://cosine.sh/gh/stud0709/oms4web/pull/41
Author: Yuriy Dzhenyeyev